### PR TITLE
fix: stock vim on Catalina does not support diffopt+=vertical

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -177,7 +177,9 @@ set spellfile=$HOME/.vim-spell-en.utf-8.add
 set complete+=kspell
 
 " Always use vertical diffs
-set diffopt+=vertical
+if &diff
+  set diffopt+=vertical
+endif
 
 " Local config
 if filereadable($HOME . "/.vimrc.local")


### PR DESCRIPTION
close #655